### PR TITLE
MODIFIED: ftp_download_ncbi_annotation.pl - NCBI decided complete gen…

### DIFF
--- a/pangenome/bin/ftp_download_ncbi_annotation.pl
+++ b/pangenome/bin/ftp_download_ncbi_annotation.pl
@@ -416,8 +416,8 @@ sub parse_data {
             }
 
             if ( $infraspecific_name =~ qr($opts{ organism_search_term }) ) {
-                next if exists $matched_assemblies{ $wgs_master };
-                $matched_assemblies{ $wgs_master }++;
+                next if exists $matched_assemblies{ $assembly_accession };
+                $matched_assemblies{ $assembly_accession }++;
             } else {
                 next;
             }


### PR DESCRIPTION
…omes don't need wgs_master ids in assembly_summary.txt, which caused a bug resulting in only the first Complete Genome getting retrieved.  Now keying the affected hash on assembly_accession, which MUST be present in assembly_summary.txt for ALL genomes.