### PR TITLE
MODIFIED: panoct_multifasta.pl - now sees empty cells (null) in match…

### DIFF
--- a/pangenome/bin/panoct_multifasta.pl
+++ b/pangenome/bin/panoct_multifasta.pl
@@ -113,7 +113,7 @@ sub process_matchtable {
 	    die ("ERROR: can not open file $basedir/$cluster_id.\n");
 	}
 	foreach my $feat_name (@feat_names) {
-	    if ($feat_name eq "----------") { #this is a placeholder and can be skipped
+	    if ($feat_name eq "----------" || $feat_name =~ /^$/ ) { #this is a placeholder and can be skipped
 		next;
 	    }
 	    if (!defined $feat_hash{$feat_name}) { # should not happen


### PR DESCRIPTION
…tables as placeholders as well as cells with  -------
(Branch called align_clusters_fix, really should say "panoct_multifasta_fix")